### PR TITLE
Make codecs dataclasses

### DIFF
--- a/brainframe/api/bf_codecs/alarm_codecs.py
+++ b/brainframe/api/bf_codecs/alarm_codecs.py
@@ -1,46 +1,47 @@
 from typing import List, Optional
 
+from dataclasses import dataclass
+
 from .base_codecs import Codec
 from .condition_codecs import ZoneAlarmCountCondition, ZoneAlarmRateCondition
 
 
+@dataclass
 class ZoneAlarm(Codec):
     """This is the configuration for an alarm."""
 
-    def __init__(self, *,
-                 name: str,
-                 count_conditions: List[ZoneAlarmCountCondition],
-                 rate_conditions: List[ZoneAlarmRateCondition],
-                 use_active_time: bool,
-                 active_start_time: str,
-                 active_end_time: str,
-                 id_: int = None,
-                 zone_id: int = None,
-                 stream_id: int = None):
-        self.name: str = name
-        """A friendly name for the zone alarm"""
-        self.id: int = id_
-        """A unique identifier"""
-        self.zone_id: int = zone_id
-        """The ID of the zone this alarm is associated with"""
-        self.stream_id: int = stream_id
-        """The ID of the stream the associated zone is in"""
-        self.count_conditions: List[ZoneAlarmCountCondition] = count_conditions
-        """All count conditions for this alarm"""
-        self.rate_conditions: List[ZoneAlarmRateCondition] = rate_conditions
-        """All rate conditions for this alarm"""
-        self.use_active_time: bool = use_active_time
-        """If True, the alarm will only be triggered when the current time is
-        between the active_start_time and active_end_time.
-        """
-        self.active_start_time: str = active_start_time
-        """The time of day where this alarm starts being active, in the format
-        "hh:mm:ss"
-        """
-        self.active_end_time: str = active_end_time
-        """The time of day where this alarm starts being active, in the format
-        "hh:mm:ss"
-        """
+    name: str
+    """A friendly name for the zone alarm"""
+
+    zone_id: int
+    """The ID of the zone this alarm is associated with"""
+
+    stream_id: int
+    """The ID of the stream the associated zone is in"""
+
+    count_conditions: List[ZoneAlarmCountCondition]
+    """All count conditions for this alarm"""
+
+    rate_conditions: List[ZoneAlarmRateCondition]
+    """All rate conditions for this alarm"""
+
+    use_active_time: bool
+    """If True, the alarm will only be triggered when the current time is
+    between the active_start_time and active_end_time.
+    """
+
+    active_start_time: str
+    """The time of day where this alarm starts being active, in the format
+    "hh:mm:ss"
+    """
+
+    active_end_time: str
+    """The time of day where this alarm starts being active, in the format
+    "hh:mm:ss"
+    """
+
+    id: Optional[int] = None
+    """A unique identifier"""
 
     def to_dict(self):
         d = dict(self.__dict__)
@@ -59,7 +60,7 @@ class ZoneAlarm(Codec):
                            for cond in d["rate_conditions"]]
 
         return ZoneAlarm(name=d["name"],
-                         id_=d["id"],
+                         id=d["id"],
                          count_conditions=count_conditions,
                          rate_conditions=rate_conditions,
                          use_active_time=d["use_active_time"],
@@ -69,37 +70,36 @@ class ZoneAlarm(Codec):
                          stream_id=d["stream_id"])
 
 
+@dataclass
 class Alert(Codec):
     """This is sent when an Alarm has been triggered."""
 
-    def __init__(self, *,
-                 alarm_id: int,
-                 zone_id: int,
-                 stream_id: int,
-                 start_time: float,
-                 end_time: float,
-                 verified_as: Optional[bool],
-                 id_: int = None):
-        self.id: int = id_
-        """A unique identifier"""
-        self.alarm_id: int = alarm_id
-        """The ID of the alarm that this alert came from"""
-        self.zone_id: int = zone_id
-        """The ID of the zone this alert pertains to"""
-        self.stream_id: int = stream_id
-        """The ID of the stream this alert pertains to"""
-        self.start_time: float = start_time
-        """When the event started happening, in Unix Time (seconds)"""
-        self.end_time: Optional[float] = end_time
-        """When the event stopped happening, in Unix Time (seconds), or None
-        if the alert is ongoing.
-        """
-        self.verified_as: Optional[bool] = verified_as
-        """
-        - If True, then this alert was labeled by a person as legitimate
-        - If False, then this alert was labeled by a person as a false alarm
-        - If None, then this alert has not been reviewed by a person
-        """
+    alarm_id: int
+    """The ID of the alarm that this alert came from"""
+
+    zone_id: int
+    """The ID of the zone this alert pertains to"""
+
+    stream_id: int
+    """The ID of the stream this alert pertains to"""
+
+    start_time: float
+    """When the event started happening, in Unix Time (seconds)"""
+
+    end_time: Optional[float]
+    """When the event stopped happening, in Unix Time (seconds), or None
+    if the alert is ongoing.
+    """
+
+    verified_as: Optional[bool]
+    """
+    - If True, then this alert was labeled by a person as legitimate
+    - If False, then this alert was labeled by a person as a false alarm
+    - If None, then this alert has not been reviewed by a person
+    """
+
+    id: Optional[int] = None
+    """A unique identifier"""
 
     def to_dict(self):
         d = dict(self.__dict__)
@@ -107,7 +107,7 @@ class Alert(Codec):
 
     @staticmethod
     def from_dict(d):
-        return Alert(id_=d["id"],
+        return Alert(id=d["id"],
                      alarm_id=d["alarm_id"],
                      zone_id=d["zone_id"],
                      stream_id=d["stream_id"],

--- a/brainframe/api/bf_codecs/base_codecs.py
+++ b/brainframe/api/bf_codecs/base_codecs.py
@@ -20,16 +20,6 @@ class Codec(abc.ABC):
     def from_json(cls, j: str):
         return cls.from_dict(json.loads(j))
 
-    def __repr__(self):
-        """Formats a string in the format of
-        ClassName(arg1=val, arg2=val, arg3=val)"""
-        argstring = ""
-        for argname, argval in self.to_dict().items():
-            if len(argstring):
-                argstring += ", "
-            argstring += f"{argname}={argval}"
-        return f"{type(self).__name__}({argstring})"
-
     def __eq__(self, other):
         if type(other) is dict:
             return self.to_dict() == other

--- a/brainframe/api/bf_codecs/condition_codecs.py
+++ b/brainframe/api/bf_codecs/condition_codecs.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Optional
 
+from dataclasses import dataclass
+
 from .base_codecs import Codec
 from .detection_codecs import Attribute
 
@@ -46,43 +48,42 @@ class IntersectionPointType(Enum):
         return [v.value for v in cls]
 
 
+@dataclass
 class ZoneAlarmCountCondition(Codec):
     """A condition that must be met for an alarm to go off. Compares the number
     of objects in a zone to some number.
     """
 
-    def __init__(self, *,
-                 test: CountConditionTestType,
-                 check_value: int,
-                 with_class_name: str,
-                 with_attribute: Optional[Attribute],
-                 window_duration: float,
-                 window_threshold: float,
-                 intersection_point: IntersectionPointType,
-                 id_: int = None):
-        self.test: CountConditionTestType = test
-        """The way that the check value will be compared to the actual count
-        """
-        self.check_value: int = check_value
-        """The value to test the actual count against"""
-        self.with_class_name: str = with_class_name
-        """The class name of the objects to count"""
-        self.with_attribute: Optional[Attribute] = with_attribute
-        """If provided, only objects that have this attribute value will be
-        counted.
-        """
-        self.window_duration: float = window_duration
-        """The sliding window duration for this condition"""
-        self.window_threshold: float = window_threshold
-        """The portion of time during the sliding window duration that this
-        condition must be true in order for the associated alarm to trigger
-        """
-        self.intersection_point: IntersectionPointType = intersection_point
-        """The point in each detection that must be within the zone in order
-        for that detection to be counted as in that zone
-        """
-        self.id: int = id_
-        """A unique identifier"""
+    test: CountConditionTestType
+    """The way that the check value will be compared to the actual count
+    """
+
+    check_value: int
+    """The value to test the actual count against"""
+
+    with_class_name: str
+    """The class name of the objects to count"""
+
+    with_attribute: Optional[Attribute]
+    """If provided, only objects that have this attribute value will be
+    counted.
+    """
+
+    window_duration: float
+    """The sliding window duration for this condition"""
+
+    window_threshold: float
+    """The portion of time during the sliding window duration that this
+    condition must be true in order for the associated alarm to trigger
+    """
+
+    intersection_point: IntersectionPointType
+    """The point in each detection that must be within the zone in order
+    for that detection to be counted as in that zone
+    """
+
+    id: Optional[int] = None
+    """A unique identifier"""
 
     def __repr__(self):
         condition_str = condition_test_map[self.test.value]
@@ -118,7 +119,7 @@ class ZoneAlarmCountCondition(Codec):
             window_duration=d["window_duration"],
             window_threshold=d["window_threshold"],
             intersection_point=intersection_point,
-            id_=d["id"])
+            id=d["id"])
 
 
 class RateConditionTestType(Enum):
@@ -146,48 +147,47 @@ class DirectionType(Enum):
         return [v.value for v in cls]
 
 
+@dataclass
 class ZoneAlarmRateCondition(Codec):
     """A condition that must be met for an alarm to go off. Compares the rate
     of change in the count of some object against a test value.
     """
 
-    direction_map = {DirectionType.ENTERING: "entered",
-                     DirectionType.EXITING: "exited",
-                     DirectionType.ENTERING_OR_EXITING: "entered or exited"}
+    _direction_map = {DirectionType.ENTERING: "entered",
+                      DirectionType.EXITING: "exited",
+                      DirectionType.ENTERING_OR_EXITING: "entered or exited"}
 
-    def __init__(self, *,
-                 test: RateConditionTestType,
-                 duration: float,
-                 change: float,
-                 direction: DirectionType,
-                 with_class_name: str,
-                 with_attribute: Optional[Attribute],
-                 intersection_point: IntersectionPointType,
-                 id_: int = None):
-        self.test: RateConditionTestType = test
-        """The way that the change value will be compared to the actual rate"""
-        self.duration: float = duration
-        """The time in seconds for this rate change to occur"""
-        self.change: float = change
-        """The rate change value to compare the actual rate value against"""
-        self.direction: DirectionType = direction
-        """The direction of flow this condition tests for"""
-        self.with_class_name: str = with_class_name
-        """The class name of the objects to measure rate of change for"""
-        self.with_attribute: Optional[Attribute] = with_attribute
-        """If provided, only objects that have this attribute will be counted
-        in the rate calculation
-        """
-        self.intersection_point: IntersectionPointType = intersection_point
-        """The point in each detection that must be within the zone in order
-        for that detection to be counted as in that zone
-        """
-        self.id: int = id_
-        """A unique identifier"""
+    test: RateConditionTestType
+    """The way that the change value will be compared to the actual rate"""
+
+    duration: float
+    """The time in seconds for this rate change to occur"""
+
+    change: float
+    """The rate change value to compare the actual rate value against"""
+
+    direction: DirectionType
+    """The direction of flow this condition tests for"""
+
+    with_class_name: str
+    """The class name of the objects to measure rate of change for"""
+
+    with_attribute: Optional[Attribute]
+    """If provided, only objects that have this attribute will be counted
+    in the rate calculation
+    """
+
+    intersection_point: IntersectionPointType
+    """The point in each detection that must be within the zone in order
+    for that detection to be counted as in that zone
+    """
+
+    id: int = None
+    """A unique identifier"""
 
     def __repr__(self):
         condition_str = condition_test_map[self.test.value]
-        direction_str = self.direction_map[self.direction]
+        direction_str = self._direction_map[self.direction]
         return f"{condition_str} {self.change} {self.with_class_name}(s) " \
                f"{direction_str} within {self.duration} seconds"
 
@@ -220,4 +220,4 @@ class ZoneAlarmRateCondition(Codec):
             with_class_name=d["with_class_name"],
             with_attribute=with_attribute,
             intersection_point=intersection_point,
-            id_=d["id"])
+            id=d["id"])

--- a/brainframe/api/bf_codecs/config_codecs.py
+++ b/brainframe/api/bf_codecs/config_codecs.py
@@ -1,6 +1,8 @@
 from typing import Optional
 from enum import Enum
 
+from dataclasses import dataclass, field
+
 from .base_codecs import Codec
 
 
@@ -17,62 +19,57 @@ class ConnType(Enum):
         return [v.value for v in cls]
 
 
+@dataclass
 class StreamConfiguration(Codec):
     """Describes a video stream that BrainFrame may connect to and analyze.
     """
 
-    def __init__(self, *,
-                 name: str,
-                 connection_type: ConnType,
-                 connection_options: dict,
-                 runtime_options: dict,
-                 premises_id: Optional[int],
-                 metadata: dict = None,
-                 id_=None):
-        assert connection_type in ConnType, \
-            "You must feed StreamConfiguration.ConnType into connection_type" \
-            " You used a " + str(type(connection_type)) + " instead!"
+    name: str
+    """The human-readable name of the video stream"""
 
-        self.name: str = name
-        """The human-readable name of the video stream"""
-        self.premises_id: Optional[int] = premises_id
-        """The ID of the premises that this stream is a part of, or None if
-        this stream is not part of a premises
-        """
-        self.id: int = id_
-        """The unique ID of this stream"""
-        self.connection_type: ConnType = connection_type
-        """The type of stream this configuration is describing"""
-        self.connection_options: dict = connection_options
-        """Contains configuration describing how this stream can be connected
-        to. The contents of this dict will depend on the connection type.
-        
-        ConnType.IP_CAMERA:
-            ``url``: The URL of the IP camera to connect to
-            
-            ``pipeline`` (optional): A custom GStreamer pipeline to connect to
-            the IP camera with
-        
-        ConnType.FILE:
-            ``storage_id``: The storage ID of the video file to stream
-            
-            ``transcode`` (optional): If True, the video file will be
-            transcoded before being streamed. By default, this value is True.
-            
-            ``pipeline`` (optional): A custom GStreamer pipeline to connect to
-            the hosted stream of this video file with
-                
-        ConnType.WEBCAM:
-            ``device_id``: The Video4Linux device ID of the webcam
-        """
-        self.runtime_options: dict = runtime_options
-        """Key-value pairs of configuration information that changes the
-        runtime behavior of the video stream from its defaults
-        """
-        self.metadata: dict = metadata or {}
-        """Key-value pairs containing some custom user-defined set of data to
-        further describe the stream
-        """
+    premises_id: Optional[int]
+    """The ID of the premises that this stream is a part of, or None if
+    this stream is not part of a premises
+    """
+
+    connection_type: ConnType
+    """The type of stream this configuration is describing"""
+
+    connection_options: dict
+    """Contains configuration describing how this stream can be connected
+    to. The contents of this dict will depend on the connection type.
+
+    ConnType.IP_CAMERA:
+        ``url``: The URL of the IP camera to connect to
+
+        ``pipeline`` (optional): A custom GStreamer pipeline to connect to
+        the IP camera with
+
+    ConnType.FILE:
+        ``storage_id``: The storage ID of the video file to stream
+
+        ``transcode`` (optional): If True, the video file will be
+        transcoded before being streamed. By default, this value is True.
+
+        ``pipeline`` (optional): A custom GStreamer pipeline to connect to
+        the hosted stream of this video file with
+
+    ConnType.WEBCAM:
+        ``device_id``: The Video4Linux device ID of the webcam
+    """
+
+    runtime_options: dict
+    """Key-value pairs of configuration information that changes the
+    runtime behavior of the video stream from its defaults
+    """
+
+    metadata: dict = field(default_factory=dict)
+    """Key-value pairs containing some custom user-defined set of data to
+    further describe the stream
+    """
+
+    id: Optional[int] = None
+    """The unique ID of this stream"""
 
     def to_dict(self):
         d = dict(self.__dict__)
@@ -83,7 +80,7 @@ class StreamConfiguration(Codec):
     def from_dict(d):
         connection_t = ConnType(d["connection_type"])
         return StreamConfiguration(name=d["name"],
-                                   id_=d["id"],
+                                   id=d["id"],
                                    connection_type=connection_t,
                                    connection_options=d["connection_options"],
                                    runtime_options=d["runtime_options"],

--- a/brainframe/api/bf_codecs/detection_codecs.py
+++ b/brainframe/api/bf_codecs/detection_codecs.py
@@ -1,45 +1,45 @@
 from typing import Optional, List, Dict, Any
 import uuid
 
+from dataclasses import dataclass
+
 from .base_codecs import Codec
 from .identity_codecs import Identity
 
 
+@dataclass
 class Detection(Codec):
     """An object detected in a video frame. Detections can have attributes
     attached to them that provide more information about the object as well as
     other metadata like a unique tracking ID.
     """
 
-    def __init__(self, *,
-                 class_name: str,
-                 coords: List[List[int]],
-                 children: List["Detection"],
-                 attributes: Dict[str, str],
-                 with_identity: Optional[Identity],
-                 extra_data: Dict[str, Any],
-                 track_id: Optional[uuid.UUID]):
-        self.class_name: str = class_name
-        """The class of object that was detected, like 'person' or 'car'"""
-        self.coords: List[List[int]] = coords
-        """The coordinates, in pixels, of the detection in the frame"""
-        self.children: List[Detection] = children
-        self.attributes: Dict[str, str] = attributes
-        """A dict whose key is an attribute name and whose value is the value
-        of that attribute. For example, a car detection may have an attribute
-        whose key is 'type' and whose value is 'sedan'.
-        """
-        self.with_identity: Optional[Identity] = with_identity
-        """If not None, this is the identity that this detection was recognized
-        as.
-        """
-        self.extra_data: Dict[str, Any] = extra_data
-        """Any additional metadata describing this object"""
-        self.track_id: Optional[uuid.UUID] = track_id
-        """If not None, this is a unique tracking ID for the object. This ID
-        can be compared to detections from other frames to track the movement
-        of an object over time.
-        """
+    class_name: str
+    """The class of object that was detected, like 'person' or 'car'"""
+
+    coords: List[List[int]]
+    """The coordinates, in pixels, of the detection in the frame"""
+
+    children: List["Detection"]
+
+    attributes: Dict[str, str]
+    """A dict whose key is an attribute name and whose value is the value
+    of that attribute. For example, a car detection may have an attribute
+    whose key is 'type' and whose value is 'sedan'.
+    """
+
+    with_identity: Optional[Identity]
+    """If not None, this is the identity that this detection was recognized as.
+    """
+
+    extra_data: Dict[str, Any]
+    """Any additional metadata describing this object"""
+
+    track_id: Optional[uuid.UUID]
+    """If not None, this is a unique tracking ID for the object. This ID
+    can be compared to detections from other frames to track the movement
+    of an object over time.
+    """
 
     @property
     def center(self):
@@ -87,16 +87,17 @@ class Detection(Codec):
                          track_id=track_id)
 
 
+@dataclass
 class Attribute(Codec):
     """This holds an attribute of a detection. These should _not_ be made
     on the client side
     """
 
-    def __init__(self, *, category: str = None, value: str = None):
-        self.category: str = category
-        """The category of attribute being described"""
-        self.value: str = value
-        """The value for this attribute category"""
+    category: str
+    """The category of attribute being described"""
+
+    value: str
+    """The value for this attribute category"""
 
     def to_dict(self):
         return self.__dict__

--- a/brainframe/api/bf_codecs/identity_codecs.py
+++ b/brainframe/api/bf_codecs/identity_codecs.py
@@ -1,33 +1,31 @@
 from typing import List, Optional
 
+from dataclasses import dataclass, field
+
 from .base_codecs import Codec
 
 
+@dataclass
 class Identity(Codec):
     """A specific, recognizable object or person."""
 
-    def __init__(self, *,
-                 unique_name: str,
-                 nickname: str,
-                 metadata: dict = None,
-                 id_: int = None):
-        self.unique_name: str = unique_name
-        """The unique id of the identified detection.
+    unique_name: str
+    """The unique id of the identified detection.
 
-        Not to be confused with the id of the object which is a field used by
-        the database.
-        """
+    Not to be confused with the id of the object which is a field used by
+    the database.
+    """
 
-        self.nickname: str = nickname
-        """A display name for the identity which may not be unique, like a
-        person's name.
-        """
+    nickname: str
+    """A display name for the identity which may not be unique, like a
+    person's name.
+    """
 
-        self.metadata: dict = {} if metadata is None else metadata
-        """Any additional user-defined information about the identity."""
+    metadata: dict = field(default_factory=dict)
+    """Any additional user-defined information about the identity."""
 
-        self.id: int = id_
-        """A unique identifier."""
+    id: Optional[int] = None
+    """A unique identifier."""
 
     def to_dict(self):
         return self.__dict__
@@ -35,36 +33,35 @@ class Identity(Codec):
     @staticmethod
     def from_dict(d):
         return Identity(
-            id_=d["id"],
+            id=d["id"],
             unique_name=d["unique_name"],
             nickname=d["nickname"],
             metadata=d["metadata"])
 
 
+@dataclass
 class Encoding(Codec):
     """An encoding attached to an identity."""
 
-    def __init__(self, *,
-                 identity_id: int,
-                 class_name: str,
-                 from_image: Optional[int],
-                 vector: List[int],
-                 id_: int = None):
-        self.identity_id: int = identity_id
-        """The ID of the identity this encoding is associated with."""
-        self.class_name: str = class_name
-        """The class of object this encoding is for."""
-        self.from_image: Optional[int] = from_image
-        """The storage ID of the image that this encoding was created from, or
-        None if this encoding was not created from an image.
-        """
-        self.vector: List[int] = vector
-        """A low-dimensional representation of the object's appearance. This is
-        what objects found in streams will be compared to in order to decide if
-        the object is of the identity this encoding is associated with.
-        """
-        self.id: int = id_
-        """The unique ID of the encoding."""
+    identity_id: int
+    """The ID of the identity this encoding is associated with."""
+
+    class_name: str
+    """The class of object this encoding is for."""
+
+    from_image: Optional[int]
+    """The storage ID of the image that this encoding was created from, or
+    None if this encoding was not created from an image.
+    """
+
+    vector: List[int]
+    """A low-dimensional representation of the object's appearance. This is
+    what objects found in streams will be compared to in order to decide if
+    the object is of the identity this encoding is associated with.
+    """
+
+    id: Optional[int] = None
+    """The unique ID of the encoding."""
 
     def to_dict(self):
         d = dict(self.__dict__)
@@ -72,7 +69,7 @@ class Encoding(Codec):
 
     @staticmethod
     def from_dict(d):
-        return Encoding(id_=d["id"],
+        return Encoding(id=d["id"],
                         identity_id=d["identity_id"],
                         class_name=d["class_name"],
                         from_image=d["from_image"],

--- a/brainframe/api/bf_codecs/license_codecs.py
+++ b/brainframe/api/bf_codecs/license_codecs.py
@@ -2,33 +2,34 @@ from datetime import date, datetime
 from typing import Optional
 from enum import Enum
 
+from dataclasses import dataclass
+
 from .base_codecs import Codec
 
 
+@dataclass
 class LicenseTerms(Codec):
     """The terms of the currently active license."""
 
-    def __init__(self, *,
-                 online_checkin: bool,
-                 max_streams: int,
-                 journal_max_allowed_age: float,
-                 expiration_date: Optional[date]):
-        self.online_checkin: bool = online_checkin
-        """If True, the server will check in with a remote licensing server to
-        verify license terms.
-        """
-        self.max_streams: int = max_streams
-        """The maximum number of streams that may have analysis enabled at any
-        given time.
-        """
-        self.journal_max_allowed_age: float = journal_max_allowed_age
-        """The maximum amount of time in seconds that the server may hold data
-        in the journal for.
-        """
-        self.expiration_date: Optional[date] = expiration_date
-        """The date that this license expires, or None if the license is
-        perpetual.
-        """
+    online_checkin: bool
+    """If True, the server will check in with a remote licensing server to
+    verify license terms.
+    """
+
+    max_streams: int
+    """The maximum number of streams that may have analysis enabled at any
+    given time.
+    """
+
+    journal_max_allowed_age: float
+    """The maximum amount of time in seconds that the server may hold data
+    in the journal for.
+    """
+
+    expiration_date: Optional[date]
+    """The date that this license expires, or None if the license is
+    perpetual.
+    """
 
     def to_dict(self) -> dict:
         d = dict(self.__dict__)
@@ -64,16 +65,17 @@ class LicenseState(Enum):
     """No license was provided"""
 
 
+@dataclass
 class LicenseInfo(Codec):
     """Information on the licensing status of the server"""
 
-    def __init__(self, *, state: LicenseState, terms: Optional[LicenseTerms]):
-        self.state: LicenseState = state
-        """The licensing state of the server."""
-        self.terms: Optional[LicenseTerms] = terms
-        """The active license terms of the server, or None if no license is
-        loaded.
-        """
+    state: LicenseState
+    """The licensing state of the server."""
+
+    terms: Optional[LicenseTerms]
+    """The active license terms of the server, or None if no license is
+    loaded.
+    """
 
     def to_dict(self) -> dict:
         return {

--- a/brainframe/api/bf_codecs/plugin_codecs.py
+++ b/brainframe/api/bf_codecs/plugin_codecs.py
@@ -1,6 +1,8 @@
 from typing import Dict, List, Any
 from enum import Enum
 
+from dataclasses import dataclass
+
 from .base_codecs import Codec
 
 
@@ -17,6 +19,7 @@ class OptionType(Enum):
         return [v.value for v in cls]
 
 
+@dataclass
 class PluginOption(Codec):
     """A single configuration option for a plugin. Defines what type of option
     it is and its potential values.
@@ -26,38 +29,36 @@ class PluginOption(Codec):
     streams, but are overridden by stream plugin options.
     """
 
-    def __init__(self, *,
-                 type_: OptionType,
-                 default: Any,
-                 constraints: dict,
-                 description: str):
-        self.type: OptionType = type_
-        """The data type of this option's value"""
-        self.default: Any = default
-        """The default value for this option"""
-        self.constraints: dict = constraints
-        """Describes the range of valid values for this option. The content of
-        this dict depends on the type field.
+    type: OptionType
+    """The data type of this option's value"""
+
+    default: Any
+    """The default value for this option"""
+
+    constraints: dict
+    """Describes the range of valid values for this option. The content of
+    this dict depends on the type field.
+    
+    OptionType.FLOAT:
+        ``max_val``: The maximum valid float value
         
-        OptionType.FLOAT:
-            ``max_val``: The maximum valid float value
-            
-            ``min_val``: The minimum valid float value
+        ``min_val``: The minimum valid float value
+    
+    OptionType.INT:
+        ``max_val``: The maximum valid int value
         
-        OptionType.INT:
-            ``max_val``: The maximum valid int value
-            
-            ``min_val``: The minimum valid int value
-        
-        OptionType.ENUM:
-            ``choices``: A list of strings. The option's value must be one of
-            these strings.
-        
-        OptionType.BOOL:
-            This object has no constraints.
-        """
-        self.description: str = description
-        """A human-readable description of the plugin's capabilities"""
+        ``min_val``: The minimum valid int value
+    
+    OptionType.ENUM:
+        ``choices``: A list of strings. The option's value must be one of
+        these strings.
+    
+    OptionType.BOOL:
+        This object has no constraints.
+    """
+
+    description: str
+    """A human-readable description of the plugin's capabilities"""
 
     def to_dict(self):
         d = dict(self.__dict__)
@@ -67,7 +68,7 @@ class PluginOption(Codec):
     @staticmethod
     def from_dict(d):
         type_ = OptionType(d["type"])
-        return PluginOption(type_=type_,
+        return PluginOption(type=type_,
                             default=d["default"],
                             constraints=d["constraints"],
                             description=d["description"])
@@ -103,44 +104,43 @@ class SizeType(Enum):
         return [v.value for v in cls]
 
 
+@dataclass
 class NodeDescription(Codec):
     """A description of a DetectionNode, used by plugins to define what kinds
     of inputs and outputs a plugin uses.
     """
 
-    def __init__(self, *,
-                 size: SizeType,
-                 detections: List[str],
-                 attributes: Dict[str, List[str]],
-                 encoded: bool,
-                 tracked: bool,
-                 extra_data: List[str]):
-        self.size: SizeType = size
-        """Describes the amount of DetectionNodes the node either takes in as
-        input or provides as output
-        """
-        self.detections: List[str] = detections
-        """A list of detection class names, like “person” or “vehicle”. A
-        DetectionNode that meets this description must have a class name that
-        is present in this list.
-        """
-        self.attributes: Dict[str, List[str]] = attributes
-        """Key-value pairs whose key is the classification type and whose value
-        is a list of possible attributes. A DetectionNode that meets this
-        description must have a classification for each classification type
-        listed here.
-        """
-        self.encoded: bool = encoded
-        """If True, the DetectionNode must be encoded to meet this description
-        """
-        self.tracked: bool = tracked
-        """If True, the DetectionNode must be tracked to meet this description
-        """
-        self.extra_data: List[str] = extra_data
-        """A list of keys in a NodeDescription's extra_data. A DetectionNode
-        that meets this description must have extra data for each name listed
-        here.
-        """
+    size: SizeType
+    """Describes the amount of DetectionNodes the node either takes in as
+    input or provides as output
+    """
+
+    detections: List[str]
+    """A list of detection class names, like “person” or “vehicle”. A
+    DetectionNode that meets this description must have a class name that
+    is present in this list.
+    """
+
+    attributes: Dict[str, List[str]]
+    """Key-value pairs whose key is the classification type and whose value
+    is a list of possible attributes. A DetectionNode that meets this
+    description must have a classification for each classification type
+    listed here.
+    """
+
+    encoded: bool
+    """If True, the DetectionNode must be encoded to meet this description
+    """
+
+    tracked: bool
+    """If True, the DetectionNode must be tracked to meet this description
+    """
+
+    extra_data: List[str]
+    """A list of keys in a NodeDescription's extra_data. A DetectionNode
+    that meets this description must have extra data for each name listed
+    here.
+    """
 
     def to_dict(self):
         d = dict(self.__dict__)
@@ -159,35 +159,35 @@ class NodeDescription(Codec):
             extra_data=d["extra_data"])
 
 
+@dataclass
 class Plugin(Codec):
     """Metadata on a loaded plugin."""
-    def __init__(self, *,
-                 name: str,
-                 version: int,
-                 description: str,
-                 input_type: NodeDescription,
-                 output_type: NodeDescription,
-                 capability: NodeDescription,
-                 options: Dict[str, PluginOption]):
-        self.name: str = name
-        """The name of the plugin"""
-        self.version: int = version
-        """The plugin's version"""
-        self.description: str = description
-        """A human-readable description of what the plugin does"""
-        self.input_type: NodeDescription = input_type
-        """Describes the type of inference data that this plugin takes as input
-        """
-        self.output_type: NodeDescription = output_type
-        """Describes the type of inference data that this plugin produces"""
-        self.capability: NodeDescription = capability
-        """A NodeDescription which describes what this plugin does to its
-        input. It is the difference between the input and output
-        NodeDescriptions. This field is useful for inspecting a plugin to find
-        what it can do.
-        """
-        self.options: Dict[str, PluginOption] = options
-        """A dict describing the configurable options of this plugin"""
+
+    name: str
+    """The name of the plugin"""
+
+    version: int
+    """The plugin's version"""
+
+    description: str
+    """A human-readable description of what the plugin does"""
+
+    input_type: NodeDescription
+    """Describes the type of inference data that this plugin takes as input
+    """
+
+    output_type: NodeDescription
+    """Describes the type of inference data that this plugin produces"""
+
+    capability: NodeDescription
+    """A NodeDescription which describes what this plugin does to its
+    input. It is the difference between the input and output
+    NodeDescriptions. This field is useful for inspecting a plugin to find
+    what it can do.
+    """
+
+    options: Dict[str, PluginOption]
+    """A dict describing the configurable options of this plugin"""
 
     def to_dict(self):
         return {

--- a/brainframe/api/bf_codecs/premises_codecs.py
+++ b/brainframe/api/bf_codecs/premises_codecs.py
@@ -1,14 +1,19 @@
+from typing import Optional
+
+from dataclasses import dataclass
+
 from .base_codecs import Codec
 
 
+@dataclass
 class Premises(Codec):
     """Information about a specific Premises"""
 
-    def __init__(self, *, name: str, id_: int = None):
-        self.id: int = id_
-        """The unique ID of the premises"""
-        self.name: str = name
-        """The friendly name of the premises"""
+    name: str
+    """The friendly name of the premises"""
+
+    id: Optional[int] = None
+    """The unique ID of the premises"""
 
     def to_dict(self):
         d = dict(self.__dict__)
@@ -16,4 +21,4 @@ class Premises(Codec):
 
     @staticmethod
     def from_dict(d):
-        return Premises(name=d["name"], id_=d["id"])
+        return Premises(name=d["name"], id=d["id"])

--- a/brainframe/api/bf_codecs/user_codecs.py
+++ b/brainframe/api/bf_codecs/user_codecs.py
@@ -1,6 +1,8 @@
 from typing import Optional
 from enum import Enum
 
+from dataclasses import dataclass
+
 from .base_codecs import Codec
 
 
@@ -19,25 +21,24 @@ class RoleType(Enum):
         return [v.value for v in cls]
 
 
+@dataclass
 class User(Codec):
     """Contains information on a user."""
 
-    def __init__(self, *,
-                 username: str,
-                 password: Optional[str],
-                 role: RoleType,
-                 id_: int = None):
-        self.username: str = username
-        """The username used for login"""
-        self.password: Optional[str] = password
-        """This field will be None when retrieving users from the server. It
-        should only be set by the client when creating a new user or updating a
-        user's password.
-        """
-        self.role: RoleType = role
-        """The user's role"""
-        self.id: int = id_
-        """The user's unique ID"""
+    username: str
+    """The username used for login"""
+
+    password: Optional[str]
+    """This field will be None when retrieving users from the server. It
+    should only be set by the client when creating a new user or updating a
+    user's password.
+    """
+
+    role: RoleType
+    """The user's role"""
+
+    id: Optional[int] = None
+    """The user's unique ID"""
 
     def to_dict(self) -> dict:
         d = dict(self.__dict__)
@@ -50,5 +51,5 @@ class User(Codec):
             username=d["username"],
             password=d["password"],
             role=User.RoleType(d["role"]),
-            id_=d["id"],
+            id=d["id"],
         )

--- a/brainframe/api/bf_codecs/zone_codecs.py
+++ b/brainframe/api/bf_codecs/zone_codecs.py
@@ -1,35 +1,36 @@
 from collections import Counter
 from typing import List, Optional
 
+from dataclasses import dataclass, field
+
 from .base_codecs import Codec
 from .alarm_codecs import Alert, ZoneAlarm
 from .detection_codecs import Detection
 
 
+@dataclass
 class Zone(Codec):
     """The definition for a zone. It is a non-convex polygon or a line."""
 
-    def __init__(self, *,
-                 name: str,
-                 coords: List[List[int]],
-                 stream_id: int,
-                 alarms: List[ZoneAlarm] = (),
-                 id_: int = None):
-        self.name: str = name
-        """A friendly name for the zone"""
-        self.id: int = id_
-        """A unique identifier"""
-        self.stream_id: int = stream_id
-        """The ID of the stream this zone is in"""
-        self.alarms: List[ZoneAlarm] = list(alarms)
-        """All alarms that are attached to the zone"""
-        self.coords: List[List[int]] = coords
-        """Coordinates that define the region the zone occupies. It is a list
-        of lists which are two elements in size. The coordinates are in pixels
-        where the top left of the frame is [0, 0].
-        
-        Example: [[0, 0], [10, 10], [100, 500], [0, 500]]
-        """
+    name: str
+    """A friendly name for the zone"""
+
+    stream_id: int
+    """The ID of the stream this zone is in"""
+
+    coords: List[List[int]]
+    """Coordinates that define the region the zone occupies. It is a list
+    of lists which are two elements in size. The coordinates are in pixels
+    where the top left of the frame is [0, 0].
+    
+    Example: [[0, 0], [10, 10], [100, 500], [0, 500]]
+    """
+
+    alarms: List[ZoneAlarm] = field(default=list)
+    """All alarms that are attached to the zone"""
+
+    id: Optional[int] = None
+    """A unique identifier"""
 
     def get_alarm(self, alarm_id) -> Optional[ZoneAlarm]:
         """
@@ -51,47 +52,46 @@ class Zone(Codec):
     def from_dict(d):
         alarms = [ZoneAlarm.from_dict(alarm_d) for alarm_d in d["alarms"]]
         return Zone(name=d["name"],
-                    id_=d["id"],
+                    id=d["id"],
                     alarms=alarms,
                     stream_id=d["stream_id"],
                     coords=d["coords"])
 
 
+@dataclass
 class ZoneStatus(Codec):
     """The current status of everything going on inside a zone.
     """
 
-    def __init__(self, *,
-                 zone: Zone,
-                 tstamp: float,
-                 within: List[Detection],
-                 entering: List[Detection],
-                 exiting: List[Detection],
-                 alerts: List[Alert],
-                 total_entered: dict,
-                 total_exited: dict):
-        self.zone: Zone = zone
-        """The zone that this status pertains to"""
-        self.tstamp: float = tstamp
-        """The time at which this ZoneStatus was created as a Unix timestamp in
-        seconds
-        """
-        self.total_entered: dict = total_entered
-        """A dict of key-value pairs indicating how many objects have exited the
-        zone. The key is the class name, and the value is the count.
-        """
-        self.total_exited: dict = total_exited
-        """A set of key-value pairs indicating how many objects have exited the
-        zone. The key is the object type, and the value is the count.
-        """
-        self.within: List[Detection] = within
-        """A list of all detections within the zone"""
-        self.entering: List[Detection] = entering
-        """A list of all detections that entered the zone this frame"""
-        self.exiting: List[Detection] = exiting
-        """A list of all detections that have exited the zone this frame"""
-        self.alerts: List[Alert] = alerts
-        """A list of all active alerts for the zone at this frame"""
+    zone: Zone
+    """The zone that this status pertains to"""
+
+    tstamp: float
+    """The time at which this ZoneStatus was created as a Unix timestamp in
+    seconds
+    """
+
+    total_entered: dict
+    """A dict of key-value pairs indicating how many objects have exited the
+    zone. The key is the class name, and the value is the count.
+    """
+
+    total_exited: dict
+    """A set of key-value pairs indicating how many objects have exited the
+    zone. The key is the object type, and the value is the count.
+    """
+
+    within: List[Detection]
+    """A list of all detections within the zone"""
+
+    entering: List[Detection]
+    """A list of all detections that entered the zone this frame"""
+
+    exiting: List[Detection]
+    """A list of all detections that have exited the zone this frame"""
+
+    alerts: List[Alert]
+    """A list of all active alerts for the zone at this frame"""
 
     @property
     def detection_within_counts(self) -> dict:

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setup(
         "requests==2.*",
         "pillow==6.*",
         "numpy==1.*",
+        "dataclasses==0.*",
     ],
 )


### PR DESCRIPTION
Using the dataclass backport library, we are able to remove all codecs' `__init__` methods. Documentation is also more clear for fields.