### PR TITLE
Embed enums in their corresponding codecs

### DIFF
--- a/brainframe/api/bf_codecs/__init__.py
+++ b/brainframe/api/bf_codecs/__init__.py
@@ -5,11 +5,8 @@ from .condition_codecs import (
     ZoneAlarmCountCondition,
     ZoneAlarmRateCondition,
     IntersectionPointType,
-    CountConditionTestType,
-    RateConditionTestType,
-    DirectionType,
 )
-from .config_codecs import StreamConfiguration, ConnType
+from .config_codecs import StreamConfiguration
 from .identity_codecs import Identity, Encoding
 from .detection_codecs import Attribute, Detection
 from .zone_codecs import Zone, ZoneStatus
@@ -17,15 +14,12 @@ from .plugin_codecs import (
     PluginOption,
     Plugin,
     NodeDescription,
-    OptionType,
-    SizeType,
 )
 from .premises_codecs import Premises
-from .user_codecs import User, RoleType
+from .user_codecs import User
 from .license_codecs import (
     LicenseTerms,
     LicenseInfo,
     DATE_FORMAT,
-    LicenseState,
 )
 from .sorting import SortOptions, Ordering

--- a/brainframe/api/bf_codecs/base_codecs.py
+++ b/brainframe/api/bf_codecs/base_codecs.py
@@ -9,7 +9,8 @@ class Codec(abc.ABC):
     def to_dict(self) -> dict:
         pass
 
-    @abc.abstractstaticmethod
+    @staticmethod
+    @abc.abstractmethod
     def from_dict(d: dict):
         pass
 

--- a/brainframe/api/bf_codecs/condition_codecs.py
+++ b/brainframe/api/bf_codecs/condition_codecs.py
@@ -15,21 +15,6 @@ condition_test_map = {'>': "Greater than",
                       "!=": "Not Equal To"}
 
 
-class CountConditionTestType(Enum):
-    """Defines the way a count condition compares the actual value to the
-    alarm's test value.
-    """
-
-    GREATER_THAN = ">"
-    LESS_THAN = "<"
-    EQUAL_TO = "="
-    NOT_EQUAL_TO = "!="
-
-    @classmethod
-    def values(cls):
-        return [v.value for v in cls]
-
-
 class IntersectionPointType(Enum):
     """The point on a detection that must be inside a zone for the detection to
     count as being inside the zone. The most commonly used intersection point
@@ -54,7 +39,21 @@ class ZoneAlarmCountCondition(Codec):
     of objects in a zone to some number.
     """
 
-    test: CountConditionTestType
+    class TestType(Enum):
+        """Defines the way a count condition compares the actual value to the
+        alarm's test value.
+        """
+
+        GREATER_THAN = ">"
+        LESS_THAN = "<"
+        EQUAL_TO = "="
+        NOT_EQUAL_TO = "!="
+
+        @classmethod
+        def values(cls):
+            return [v.value for v in cls]
+
+    test: TestType
     """The way that the check value will be compared to the actual count
     """
 
@@ -109,7 +108,7 @@ class ZoneAlarmCountCondition(Codec):
         with_attribute = None
         if d["with_attribute"] is not None:
             with_attribute = Attribute.from_dict(d["with_attribute"])
-        test = CountConditionTestType(d["test"])
+        test = ZoneAlarmCountCondition.TestType(d["test"])
 
         return ZoneAlarmCountCondition(
             test=test,
@@ -122,42 +121,40 @@ class ZoneAlarmCountCondition(Codec):
             id=d["id"])
 
 
-class RateConditionTestType(Enum):
-    """Defines the way a rate condition compares the actual rate value to the
-    alarm's test value.
-    """
-
-    GREATER_THAN_OR_EQUAL_TO = ">="
-    LESS_THAN_OR_EQUAL_TO = "<="
-
-    @classmethod
-    def values(cls):
-        return [v.value for v in cls]
-
-
-class DirectionType(Enum):
-    """Defines the direction of flow that a rate condition pertains to."""
-
-    ENTERING = "entering"
-    EXITING = "exiting"
-    ENTERING_OR_EXITING = "entering_or_exiting"
-
-    @classmethod
-    def values(cls):
-        return [v.value for v in cls]
-
-
 @dataclass
 class ZoneAlarmRateCondition(Codec):
     """A condition that must be met for an alarm to go off. Compares the rate
     of change in the count of some object against a test value.
     """
 
+    class TestType(Enum):
+        """Defines the way a rate condition compares the actual rate value to
+        the alarm's test value.
+        """
+
+        GREATER_THAN_OR_EQUAL_TO = ">="
+        LESS_THAN_OR_EQUAL_TO = "<="
+
+        @classmethod
+        def values(cls):
+            return [v.value for v in cls]
+
+    class DirectionType(Enum):
+        """Defines the direction of flow that a rate condition pertains to."""
+
+        ENTERING = "entering"
+        EXITING = "exiting"
+        ENTERING_OR_EXITING = "entering_or_exiting"
+
+        @classmethod
+        def values(cls):
+            return [v.value for v in cls]
+
     _direction_map = {DirectionType.ENTERING: "entered",
                       DirectionType.EXITING: "exited",
                       DirectionType.ENTERING_OR_EXITING: "entered or exited"}
 
-    test: RateConditionTestType
+    test: TestType
     """The way that the change value will be compared to the actual rate"""
 
     duration: float
@@ -210,13 +207,13 @@ class ZoneAlarmRateCondition(Codec):
         with_attribute = None
         if d["with_attribute"] is not None:
             with_attribute = Attribute.from_dict(d["with_attribute"])
-        test = RateConditionTestType(d["test"])
+        test = ZoneAlarmRateCondition.TestType(d["test"])
 
         return ZoneAlarmRateCondition(
             test=test,
             duration=d["duration"],
             change=d["change"],
-            direction=DirectionType(d["direction"]),
+            direction=ZoneAlarmRateCondition.DirectionType(d["direction"]),
             with_class_name=d["with_class_name"],
             with_attribute=with_attribute,
             intersection_point=intersection_point,

--- a/brainframe/api/bf_codecs/config_codecs.py
+++ b/brainframe/api/bf_codecs/config_codecs.py
@@ -6,23 +6,22 @@ from dataclasses import dataclass, field
 from .base_codecs import Codec
 
 
-class ConnType(Enum):
-    IP_CAMERA = "ip_camera"
-    """A network camera that uses RTSP or HTTP"""
-    WEBCAM = "webcam"
-    """A webcam (usually USB)"""
-    FILE = "file"
-    """An uploaded video file"""
-
-    @classmethod
-    def values(cls):
-        return [v.value for v in cls]
-
-
 @dataclass
 class StreamConfiguration(Codec):
     """Describes a video stream that BrainFrame may connect to and analyze.
     """
+
+    class ConnType(Enum):
+        IP_CAMERA = "ip_camera"
+        """A network camera that uses RTSP or HTTP"""
+        WEBCAM = "webcam"
+        """A webcam (usually USB)"""
+        FILE = "file"
+        """An uploaded video file"""
+
+        @classmethod
+        def values(cls):
+            return [v.value for v in cls]
 
     name: str
     """The human-readable name of the video stream"""
@@ -78,7 +77,7 @@ class StreamConfiguration(Codec):
 
     @staticmethod
     def from_dict(d):
-        connection_t = ConnType(d["connection_type"])
+        connection_t = StreamConfiguration.ConnType(d["connection_type"])
         return StreamConfiguration(name=d["name"],
                                    id=d["id"],
                                    connection_type=connection_t,

--- a/brainframe/api/bf_codecs/license_codecs.py
+++ b/brainframe/api/bf_codecs/license_codecs.py
@@ -54,22 +54,21 @@ class LicenseTerms(Codec):
         return terms
 
 
-class LicenseState(Enum):
-    VALID = "valid"
-    """A valid license is loaded, features should be enabled"""
-    INVALID = "invalid"
-    """A license was provided, but did not pass validation"""
-    EXPIRED = "expired"
-    """A license was provided, but it has expired"""
-    MISSING = "missing"
-    """No license was provided"""
-
-
 @dataclass
 class LicenseInfo(Codec):
     """Information on the licensing status of the server"""
 
-    state: LicenseState
+    class State(Enum):
+        VALID = "valid"
+        """A valid license is loaded, features should be enabled"""
+        INVALID = "invalid"
+        """A license was provided, but did not pass validation"""
+        EXPIRED = "expired"
+        """A license was provided, but it has expired"""
+        MISSING = "missing"
+        """No license was provided"""
+
+    state: State
     """The licensing state of the server."""
 
     terms: Optional[LicenseTerms]
@@ -90,7 +89,7 @@ class LicenseInfo(Codec):
             terms = LicenseTerms.from_dict(d["terms"])
 
         return LicenseInfo(
-            state=LicenseState(d["state"]),
+            state=LicenseInfo.State(d["state"]),
             terms=terms,
         )
 

--- a/brainframe/api/bf_codecs/plugin_codecs.py
+++ b/brainframe/api/bf_codecs/plugin_codecs.py
@@ -1,22 +1,9 @@
-from typing import Dict, List, Any
 from enum import Enum
+from typing import Dict, List, Any
 
 from dataclasses import dataclass
 
 from .base_codecs import Codec
-
-
-class OptionType(Enum):
-    """The data type of a plugin option"""
-
-    FLOAT = "float"
-    INT = "int"
-    ENUM = "enum"
-    BOOL = "bool"
-
-    @classmethod
-    def values(cls):
-        return [v.value for v in cls]
 
 
 @dataclass
@@ -29,7 +16,19 @@ class PluginOption(Codec):
     streams, but are overridden by stream plugin options.
     """
 
-    type: OptionType
+    class Type(Enum):
+        """The data type of a plugin option"""
+
+        FLOAT = "float"
+        INT = "int"
+        ENUM = "enum"
+        BOOL = "bool"
+
+        @classmethod
+        def values(cls):
+            return [v.value for v in cls]
+
+    type: Type
     """The data type of this option's value"""
 
     default: Any
@@ -67,41 +66,11 @@ class PluginOption(Codec):
 
     @staticmethod
     def from_dict(d):
-        type_ = OptionType(d["type"])
+        type_ = PluginOption.Type(d["type"])
         return PluginOption(type=type_,
                             default=d["default"],
                             constraints=d["constraints"],
                             description=d["description"])
-
-
-class SizeType(Enum):
-    """Describes the amount of DetectionNodes a plugin takes as input or
-    provides as output.
-    """
-
-    NONE = "none"
-    """Input: The plugin takes nothing as input, like for an object detector.
-    
-    Output: Plugins cannot have a NONE output.
-    """
-    SINGLE = "single"
-    """Input: The plugin takes a single DetectionNode as input, like for a
-    classifier.
-    
-    Output: The plugin provides a single modified DetectionNode as output, like
-    for a classifier.
-    """
-    ALL = "all"
-    """Input: The plugin takes all instances of a class as input, like for a
-    tracker.
-    
-    Output: The plugin provides all instances of a class as output, like for a
-    detector.
-    """
-
-    @classmethod
-    def values(cls):
-        return [v.value for v in cls]
 
 
 @dataclass
@@ -110,7 +79,37 @@ class NodeDescription(Codec):
     of inputs and outputs a plugin uses.
     """
 
-    size: SizeType
+    class Size(Enum):
+        """Describes the amount of DetectionNodes a plugin takes as input or
+        provides as output.
+        """
+
+        NONE = "none"
+        """Input: The plugin takes nothing as input, like for an object
+        detector.
+
+        Output: Plugins cannot have a NONE output.
+        """
+        SINGLE = "single"
+        """Input: The plugin takes a single DetectionNode as input, like for a
+        classifier.
+
+        Output: The plugin provides a single modified DetectionNode as output,
+        like for a classifier.
+        """
+        ALL = "all"
+        """Input: The plugin takes all instances of a class as input, like for
+        a tracker.
+
+        Output: The plugin provides all instances of a class as output, like
+        for a detector.
+        """
+
+        @classmethod
+        def values(cls):
+            return [v.value for v in cls]
+
+    size: Size
     """Describes the amount of DetectionNodes the node either takes in as
     input or provides as output
     """
@@ -149,7 +148,7 @@ class NodeDescription(Codec):
 
     @staticmethod
     def from_dict(d):
-        size = SizeType(d["size"])
+        size = NodeDescription.Size(d["size"])
         return NodeDescription(
             size=size,
             detections=d["detections"],

--- a/brainframe/api/bf_codecs/user_codecs.py
+++ b/brainframe/api/bf_codecs/user_codecs.py
@@ -6,24 +6,23 @@ from dataclasses import dataclass
 from .base_codecs import Codec
 
 
-class RoleType(Enum):
-    """Controls the level of access a user has to API endpoints."""
-
-    EDITOR = "editor"
-    """A user that can access most endpoints but cannot do administrative tasks
-    like adding users and managing the license.
-    """
-    ADMIN = "admin"
-    """A user that can access all endpoints."""
-
-    @classmethod
-    def values(cls):
-        return [v.value for v in cls]
-
-
 @dataclass
 class User(Codec):
     """Contains information on a user."""
+
+    class Role(Enum):
+        """Controls the level of access a user has to API endpoints."""
+
+        EDITOR = "editor"
+        """A user that can access most endpoints but cannot do administrative
+        tasks like adding users and managing the license.
+        """
+        ADMIN = "admin"
+        """A user that can access all endpoints."""
+
+        @classmethod
+        def values(cls):
+            return [v.value for v in cls]
 
     username: str
     """The username used for login"""
@@ -34,7 +33,7 @@ class User(Codec):
     user's password.
     """
 
-    role: RoleType
+    role: Role
     """The user's role"""
 
     id: Optional[int] = None
@@ -50,6 +49,6 @@ class User(Codec):
         return User(
             username=d["username"],
             password=d["password"],
-            role=RoleType(d["role"]),
+            role=User.Role(d["role"]),
             id=d["id"],
         )

--- a/brainframe/api/bf_errors.py
+++ b/brainframe/api/bf_errors.py
@@ -175,8 +175,8 @@ class TooManyDetectionsInImageError(BaseAPIError):
 
 @_register_error()
 class ImageAlreadyEncodedError(BaseAPIError):
-    """There was an attempt to encode an image that has already been encoded for
-    a given identity and a given class.
+    """There was an attempt to encode an image that has already been encoded
+    for a given identity and a given class.
     """
 
 

--- a/brainframe/api/stub.py
+++ b/brainframe/api/stub.py
@@ -4,7 +4,6 @@ from time import sleep, time
 from requests.exceptions import ConnectionError, ReadTimeout
 
 from .bf_errors import UnauthorizedError, UnknownError
-from .bf_codecs import LicenseState
 from . import stubs
 from .stubs.base_stub import DEFAULT_TIMEOUT
 


### PR DESCRIPTION
This undoes a change I made to bring all enums out into the bf_codecs module. We believe that this will allow users to have a better understanding of where the enums are intended to be used.