### PR TITLE
Add methods for setting and deleting a capsule

### DIFF
--- a/brainframe/api/bf_errors.py
+++ b/brainframe/api/bf_errors.py
@@ -292,6 +292,17 @@ class RemoteConnectionError(BaseAPIError):
     """
 
 
+@_server_origin_error()
+class InvalidCapsuleError(BaseAPIError):
+    """The provided capsule could not be loaded."""
+
+
+@_server_origin_error()
+class IncompatibleCapsuleError(BaseAPIError):
+    """The provided capsule is not compatible with this version of BrainFrame.
+    """
+
+
 class ServerNotReadyError(BaseAPIError):
     """The client was able to communicate with the server, but the server had
     not completed startup or was in an invalid state"""

--- a/brainframe/api/stubs/base_stub.py
+++ b/brainframe/api/stubs/base_stub.py
@@ -58,13 +58,13 @@ class BaseStub:
             return json.loads(resp.content), resp.headers
         return None, resp.headers
 
-    def _put_json(self, api_url, timeout, json_data):
+    def _put_json(self, api_url, timeout, json_data) -> Optional[Any]:
         """Send a PUT request to the given URL.
 
         :param api_url: The /api/blah/blah to append to the base_url
         :param timeout: The timeout to use for this request
         :param json_data: Pre-formatted JSON to send
-        :return: The JSON response as a dict, or None if none was sent
+        :return: The parsed response, or None if none was sent
         """
         resp = self._put(api_url,
                          timeout,

--- a/brainframe/api/stubs/base_stub.py
+++ b/brainframe/api/stubs/base_stub.py
@@ -58,7 +58,7 @@ class BaseStub:
             return json.loads(resp.content), resp.headers
         return None, resp.headers
 
-    def _put_json(self, api_url, timeout, json_data) -> Optional[Any]:
+    def _put_json(self, api_url, timeout, json_data) -> Any:
         """Send a PUT request to the given URL.
 
         :param api_url: The /api/blah/blah to append to the base_url

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -30,12 +30,12 @@ class CapsuleStubMixin(BaseStub):
         return [Capsule.from_dict(d) for d in capsules]
 
     def set_capsule(self, storage_id: int,
-                    source_code_path: Optional[Path] = None,
+                    source_path: Optional[Path] = None,
                     timeout=DEFAULT_TIMEOUT) -> Capsule:
         """Sends capsule data to the server to be loaded and initialized.
 
         :param storage_id: The ID of the raw capsule data
-        :param source_code_path: The path to the source code on the development
+        :param source_path: The path to the source code on the development
             machine, if available. Providing this allows stack traces to point
             to the correct source location.
         :param timeout: The timeout to use for this request
@@ -44,7 +44,7 @@ class CapsuleStubMixin(BaseStub):
         req = f"/api/plugins"
         req_object = {
             "storage_id": storage_id,
-            "source_code_path": str(source_code_path),
+            "source_path": str(source_path),
         }
         capsule, _ = self._put_json(req, timeout, json.dumps(req_object))
         return Capsule.from_dict(capsule)

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -33,7 +33,7 @@ class CapsuleStubMixin(StorageStubMixin):
 
     def load_capsule(self, storage_id: int,
                      source_path: Optional[Path] = None,
-                     timeout=DEFAULT_TIMEOUT) -> Capsule:
+                     timeout: float = DEFAULT_TIMEOUT) -> Capsule:
         """Loads and initializes a capsule from capsule data in storage.
 
         :param storage_id: The ID of the raw capsule data in storage
@@ -53,9 +53,9 @@ class CapsuleStubMixin(StorageStubMixin):
         capsule = self._put_json(req, timeout, json.dumps(req_object))
         return Capsule.from_dict(capsule)
 
-    def upload_and_load_capsule(self, data: Union[bytes, BinaryIO, Iterable],
+    def upload_and_load_capsule(self, data: Union[bytes, BinaryIO],
                                 source_path: Optional[Path] = None,
-                                timeout=DEFAULT_TIMEOUT) -> Capsule:
+                                timeout: float = DEFAULT_TIMEOUT) -> Capsule:
         """Uploads capsule data to storage, then loads and initializes a
         capsule from it. This is a utility method that combines the
         functionality of `new_storage` and `load_capsule`.
@@ -78,7 +78,7 @@ class CapsuleStubMixin(StorageStubMixin):
                                  timeout=remaining_time)
 
     def unload_capsule(self, capsule_name: str,
-                       timeout=DEFAULT_TIMEOUT) -> None:
+                       timeout: float = DEFAULT_TIMEOUT) -> None:
         """Unloads a capsule and deletes its data from storage. This method may
         only be used with capsules that were loaded through the REST API.
 

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -1,7 +1,9 @@
 import json
 from pathlib import Path
 from time import time
-from typing import Dict, List, Optional, BinaryIO, Union, Iterable
+from typing import Dict, List, Optional, BinaryIO, Union
+
+import requests.exceptions
 
 from brainframe.api.bf_codecs import Capsule
 from .base_stub import DEFAULT_TIMEOUT
@@ -72,6 +74,9 @@ class CapsuleStubMixin(StorageStubMixin):
                                       mime_type="application/octet-stream",
                                       timeout=timeout)
         remaining_time = timeout - (time() - request_start)
+
+        if remaining_time <= 0:
+            raise requests.exceptions.Timeout()
 
         return self.load_capsule(storage_id,
                                  source_path,

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -49,6 +49,16 @@ class CapsuleStubMixin(BaseStub):
         capsule = self._put_json(req, timeout, json.dumps(req_object))
         return Capsule.from_dict(capsule)
 
+    def unload_capsule(self, capsule_name: str, timeout=DEFAULT_TIMEOUT):
+        """Unloads a capsule. This method may only be used with capsules that
+        were loaded through the REST API.
+
+        :param capsule_name: The name of the capsule to unload
+        :param timeout: The timeout to use for this request
+        """
+        req = f"/api/plugins/{capsule_name}"
+        self._delete(req, timeout)
+
     def get_capsule_option_vals(self, capsule_name, stream_id=None,
                                 timeout=DEFAULT_TIMEOUT) \
             -> Dict[str, object]:

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -1,5 +1,6 @@
 import json
 from typing import Dict, List, Optional
+from pathlib import Path
 
 from brainframe.api.bf_codecs import Capsule
 from .base_stub import BaseStub, DEFAULT_TIMEOUT
@@ -27,6 +28,26 @@ class CapsuleStubMixin(BaseStub):
         req = "/api/plugins"
         capsules, _ = self._get_json(req, timeout)
         return [Capsule.from_dict(d) for d in capsules]
+
+    def set_capsule(self, storage_id: int,
+                    source_code_path: Optional[Path] = None,
+                    timeout=DEFAULT_TIMEOUT) -> Capsule:
+        """Sends capsule data to the server to be loaded and initialized.
+
+        :param storage_id: The ID of the raw capsule data
+        :param source_code_path: The path to the source code on the development
+            machine, if available. Providing this allows stack traces to point
+            to the correct source location.
+        :param timeout: The timeout to use for this request
+        :return: The loaded capsule
+        """
+        req = f"/api/plugins"
+        req_object = {
+            "storage_id": storage_id,
+            "source_code_path": str(source_code_path),
+        }
+        capsule, _ = self._put_json(req, timeout, json.dumps(req_object))
+        return Capsule.from_dict(capsule)
 
     def get_capsule_option_vals(self, capsule_name, stream_id=None,
                                 timeout=DEFAULT_TIMEOUT) \

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -44,7 +44,9 @@ class CapsuleStubMixin(BaseStub):
         req = f"/api/plugins"
         req_object = {
             "storage_id": storage_id,
-            "source_path": str(source_path),
+            "dev_options": {
+                "source_path": str(source_path),
+            },
         }
         capsule = self._put_json(req, timeout, json.dumps(req_object))
         return Capsule.from_dict(capsule)

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -49,7 +49,7 @@ class CapsuleStubMixin(BaseStub):
         capsule = self._put_json(req, timeout, json.dumps(req_object))
         return Capsule.from_dict(capsule)
 
-    def unload_capsule(self, capsule_name: str, timeout=DEFAULT_TIMEOUT):
+    def delete_capsule(self, capsule_name: str, timeout=DEFAULT_TIMEOUT):
         """Unloads a capsule. This method may only be used with capsules that
         were loaded through the REST API.
 

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -46,7 +46,7 @@ class CapsuleStubMixin(BaseStub):
             "storage_id": storage_id,
             "source_path": str(source_path),
         }
-        capsule, _ = self._put_json(req, timeout, json.dumps(req_object))
+        capsule = self._put_json(req, timeout, json.dumps(req_object))
         return Capsule.from_dict(capsule)
 
     def get_capsule_option_vals(self, capsule_name, stream_id=None,

--- a/brainframe/api/stubs/capsules.py
+++ b/brainframe/api/stubs/capsules.py
@@ -66,21 +66,16 @@ class CapsuleStubMixin(StorageStubMixin):
         :param source_path: If available, the path to the source code on the
             development machine can be provided. Doing so allows stack traces
             to point to the correct source location.
-        :param timeout: The total timeout to use for all requests
+        :param timeout: The timeout to use for each request
         :return: The loaded capsule
         """
-        request_start = time()
         storage_id = self.new_storage(data,
                                       mime_type="application/octet-stream",
                                       timeout=timeout)
-        remaining_time = timeout - (time() - request_start)
-
-        if remaining_time <= 0:
-            raise requests.exceptions.Timeout()
 
         return self.load_capsule(storage_id,
                                  source_path,
-                                 timeout=remaining_time)
+                                 timeout=timeout)
 
     def unload_capsule(self, capsule_name: str,
                        timeout: float = DEFAULT_TIMEOUT) -> None:

--- a/brainframe/api/stubs/storage.py
+++ b/brainframe/api/stubs/storage.py
@@ -1,8 +1,8 @@
+import json
 from io import BytesIO
 from typing import BinaryIO, Iterable, Tuple, Union
 
 import numpy as np
-import json
 from PIL import Image
 
 from brainframe.api.bf_codecs import image_utils

--- a/docs/capsules.rst
+++ b/docs/capsules.rst
@@ -13,6 +13,10 @@ API Methods
 
 .. automethod:: brainframe.api.BrainFrameAPI.get_capsules
 
+.. automethod:: brainframe.api.BrainFrameAPI.set_capsule
+
+.. automethod:: brainframe.api.BrainFrameAPI.delete_capsule
+
 .. automethod:: brainframe.api.BrainFrameAPI.get_capsule_option_vals
 
 .. automethod:: brainframe.api.BrainFrameAPI.set_capsule_option_vals


### PR DESCRIPTION
This PR adds methods corresponding to the `PUT /api/plugins` and `DELETE /api/plugins/{capsule_name}` endpoints.