### PR TITLE
Add license info to PUT /api/cloud_tokens

### DIFF
--- a/brainframe/api/stubs/cloud_tokens.py
+++ b/brainframe/api/stubs/cloud_tokens.py
@@ -1,10 +1,12 @@
-from brainframe.api.bf_codecs import CloudTokens, CloudUserInfo
+from typing import Tuple
+
+from brainframe.api.bf_codecs import CloudTokens, CloudUserInfo, LicenseInfo
 from .base_stub import BaseStub, DEFAULT_TIMEOUT
 
 
 class CloudTokensStubMixin(BaseStub):
     def set_cloud_tokens(self, cloud_tokens: CloudTokens,
-                         timeout=DEFAULT_TIMEOUT) -> CloudUserInfo:
+                         timeout=DEFAULT_TIMEOUT) -> Tuple[CloudUserInfo, LicenseInfo]:
         """Authorizes the server against BrainFrame Cloud using the provided tokens.
 
         :param cloud_tokens: The tokens to use for authorization
@@ -12,6 +14,9 @@ class CloudTokensStubMixin(BaseStub):
         :return: Info on the BrainFrame Cloud user that corresponds to these tokens
         """
         req = "/api/cloud_tokens"
-        user_info_dict = self._put_codec(req, timeout, cloud_tokens)
+        login_result = self._put_codec(req, timeout, cloud_tokens)
 
-        return CloudUserInfo.from_dict(user_info_dict)
+        cloud_user_info = CloudUserInfo.from_dict(login_result["cloud_user_info"])
+        license_info = LicenseInfo.from_dict(login_result["license_info"])
+
+        return cloud_user_info, license_info


### PR DESCRIPTION
The server will now fetch a license automatically when a new user is logged in via this API, so it will also provide the corresponding license info in the body.