### PR TITLE
Add method for GET /api/cloud_user

### DIFF
--- a/brainframe/api/bf_errors.py
+++ b/brainframe/api/bf_errors.py
@@ -308,6 +308,11 @@ class UnauthorizedTokensError(BaseAPIError):
     """The provided tokens do not correctly authorize a BrainFrame Cloud user"""
 
 
+@_server_origin_error()
+class CloudUserNotFoundError(BaseAPIError):
+    """No cloud user is logged in"""
+
+
 class ServerNotReadyError(BaseAPIError):
     """The client was able to communicate with the server, but the server had
     not completed startup or was in an invalid state"""

--- a/brainframe/api/stub.py
+++ b/brainframe/api/stub.py
@@ -22,7 +22,8 @@ class BrainFrameAPI(stubs.AlertStubMixin,
                     stubs.PremisesStubMixin,
                     stubs.UserStubMixin,
                     stubs.LicenseStubMixIn,
-                    stubs.CloudTokensStubMixin):
+                    stubs.CloudTokensStubMixin,
+                    stubs.CloudUsersStubMixIn):
     """Provides access to BrainFrame API endpoints."""
 
     def __init__(self, server_url=None, credentials: Tuple[str, str] = None):

--- a/brainframe/api/stubs/__init__.py
+++ b/brainframe/api/stubs/__init__.py
@@ -13,4 +13,5 @@ from .premises import PremisesStubMixin
 from .users import UserStubMixin
 from .licenses import LicenseStubMixIn
 from .cloud_tokens import CloudTokensStubMixin
+from .cloud_users import CloudUsersStubMixIn
 from .base_stub import BaseStub

--- a/brainframe/api/stubs/cloud_users.py
+++ b/brainframe/api/stubs/cloud_users.py
@@ -17,6 +17,7 @@ class CloudUsersStubMixIn(BaseStub):
         req = f"/api/cloud_user"
         try:
             data, _ = self._get_json(req, timeout=timeout)
-            return CloudUserInfo.from_dict(data)
         except CloudUserNotFoundError:
             return None
+        else:
+            return CloudUserInfo.from_dict(data)

--- a/brainframe/api/stubs/cloud_users.py
+++ b/brainframe/api/stubs/cloud_users.py
@@ -7,7 +7,13 @@ from .base_stub import BaseStub, DEFAULT_TIMEOUT
 
 
 class CloudUsersStubMixIn(BaseStub):
-    def get_cloud_user(self, timeout=DEFAULT_TIMEOUT) -> Optional[CloudUserInfo]:
+    def get_current_cloud_user(self, timeout=DEFAULT_TIMEOUT) \
+            -> Optional[CloudUserInfo]:
+        """Gets information on the cloud user that's currently logged in.
+
+        :param timeout: The timeout to use for this request
+        :return: Information on the cloud user, or None if no user is logged in
+        """
         req = f"/api/cloud_user"
         try:
             data, _ = self._get_json(req, timeout=timeout)

--- a/brainframe/api/stubs/cloud_users.py
+++ b/brainframe/api/stubs/cloud_users.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+from brainframe.api.bf_codecs import CloudUserInfo
+from brainframe.api.bf_errors import CloudUserNotFoundError
+
+from .base_stub import BaseStub, DEFAULT_TIMEOUT
+
+
+class CloudUsersStubMixIn(BaseStub):
+    def get_cloud_user(self, timeout=DEFAULT_TIMEOUT) -> Optional[CloudUserInfo]:
+        req = f"/api/cloud_user"
+        try:
+            data, _ = self._get_json(req, timeout=timeout)
+            return CloudUserInfo.from_dict(data)
+        except CloudUserNotFoundError:
+            return None


### PR DESCRIPTION
Adds a method for an API that allows clients to get information on the currently logged-in cloud user. The server returns a 404 when a user is not logged in, but this method returns `None` in this case instead.