### PR TITLE
Add error and API for read-only zone behavior

### DIFF
--- a/brainframe/api/bf_errors.py
+++ b/brainframe/api/bf_errors.py
@@ -77,6 +77,11 @@ class ZoneNotDeletableError(BaseAPIError):
 
 
 @_server_origin_error()
+class ZoneNotEditableError(BaseAPIError):
+    """A client tried to edit a read-only Zone"""
+
+
+@_server_origin_error()
 class AlertNotFoundError(BaseAPIError):
     """An Alert specified by the client could not be found."""
 

--- a/brainframe/api/stubs/base_stub.py
+++ b/brainframe/api/stubs/base_stub.py
@@ -271,6 +271,18 @@ class BaseStub:
 
         return self._send_authorized(request, timeout)
 
+    def _options(self, api_url: str, timeout: float) -> Response:
+        """Sends an OPTIONS request to the given URL, managing authentication and
+        handling errors as necessary.
+
+        :param api_url: The /api/blah/blah to append to the base_url
+        :param timeout: The timeout to use for this request
+        :return: The response object
+        """
+        request = requests.Request(method="OPTIONS", url=self._full_url(api_url))
+
+        return self._send_authorized(request, timeout)
+
     def _full_url(self, api_url):
         """Converts an API URL path to a fully qualified URL.
 

--- a/brainframe/api/stubs/zones.py
+++ b/brainframe/api/stubs/zones.py
@@ -57,7 +57,7 @@ class ZoneStubMixin(BaseStub):
         req = f"/api/zones/{zone_id}"
         self._delete(req, timeout)
 
-    def is_zone_read_only(self, zone_id: int, timeout=DEFAULT_TIMEOUT) -> bool:
+    def is_zone_read_only(self, zone_id: int, timeout: float = DEFAULT_TIMEOUT) -> bool:
         """Checks if a zone is read-only. This refers to the zone itself, not its
         alarms or any other attached resources.
 

--- a/brainframe/api/stubs/zones.py
+++ b/brainframe/api/stubs/zones.py
@@ -73,4 +73,4 @@ class ZoneStubMixin(BaseStub):
         allowed_methods = allow_header.split(",")
         allowed_methods = [m.strip().upper() for m in allowed_methods]
 
-        return "POST" in allowed_methods
+        return "POST" not in allowed_methods

--- a/brainframe/api/stubs/zones.py
+++ b/brainframe/api/stubs/zones.py
@@ -56,3 +56,21 @@ class ZoneStubMixin(BaseStub):
         """
         req = f"/api/zones/{zone_id}"
         self._delete(req, timeout)
+
+    def is_zone_read_only(self, zone_id: int, timeout=DEFAULT_TIMEOUT) -> bool:
+        """Checks if a zone is read-only. This refers to the zone itself, not its
+        alarms or any other attached resources.
+
+        :param zone_id: The ID of the zone to check
+        :param timeout: The timeout to use for this request
+        :return: True if the zone is read-only
+        """
+        req = f"/api/zones/{zone_id}"
+        resp = self._options(req, timeout)
+
+        # Parse the Allow header, which is a string of comma-separated method names
+        allow_header = resp.headers["Allow"]
+        allowed_methods = allow_header.split(",")
+        allowed_methods = [m.strip().upper() for m in allowed_methods]
+
+        return "POST" in allowed_methods


### PR DESCRIPTION
Zones can soon be read-only, and attempting to edit them results in an error. This also adds a new method that checks a zone's OPTIONS headers to see if the zone is editable.