### PR TITLE
Fix the issue of api.get_zone_status_stream not return after timeout

### DIFF
--- a/brainframe/api/stubs/zone_statuses.py
+++ b/brainframe/api/stubs/zone_statuses.py
@@ -1,5 +1,4 @@
 import json
-import time
 from typing import Dict, Generator
 
 import requests
@@ -52,7 +51,6 @@ class ZoneStatusStubMixin(BaseStub):
             resp = self._get(req, timeout=timeout)
 
             packets = resp.iter_lines(delimiter=b"\r\n")
-            timeout_start = time.time()
             while True:
                 try:
                     packet = next(packets)

--- a/brainframe/api/stubs/zone_statuses.py
+++ b/brainframe/api/stubs/zone_statuses.py
@@ -1,4 +1,5 @@
 import json
+import time
 from typing import Dict, Generator
 
 import requests
@@ -51,6 +52,7 @@ class ZoneStatusStubMixin(BaseStub):
             resp = self._get(req, timeout=timeout)
 
             packets = resp.iter_lines(delimiter=b"\r\n")
+            timeout_start = time.time()
             while True:
                 try:
                     packet = next(packets)
@@ -66,7 +68,10 @@ class ZoneStatusStubMixin(BaseStub):
                     raise bf_errors.ServerNotReadyError(message)
 
                 if packet == b'':
-                    continue
+                    if time.time() < timeout_start + timeout:
+                        continue
+                    else:
+                        break
 
                 # Parse the line
                 zone_statuses_dict = json.loads(packet)

--- a/brainframe/api/stubs/zone_statuses.py
+++ b/brainframe/api/stubs/zone_statuses.py
@@ -68,18 +68,15 @@ class ZoneStatusStubMixin(BaseStub):
                     raise bf_errors.ServerNotReadyError(message)
 
                 if packet == b'':
-                    if time.time() < timeout_start + timeout:
-                        continue
-                    else:
-                        break
+                    processed={}
+                else:
+                    # Parse the line
+                    zone_statuses_dict = json.loads(packet)
 
-                # Parse the line
-                zone_statuses_dict = json.loads(packet)
-
-                processed = {
-                    int(s_id): {key: bf_codecs.ZoneStatus.from_dict(val)
-                                for key, val in statuses.items()}
-                    for s_id, statuses in zone_statuses_dict.items()}
+                    processed = {
+                        int(s_id): {key: bf_codecs.ZoneStatus.from_dict(val)
+                                    for key, val in statuses.items()}
+                        for s_id, statuses in zone_statuses_dict.items()}
                 yield processed
 
         return zone_status_iterator()


### PR DESCRIPTION
Currently, get_zone_status_stream will freeze when a video stream stops; timeout will not work. This can be reproduced if we host a stream using ffmeg/ffserver, use it as ip camera input of brainframe, and wait till the end of video file playback.

The solution implemented here is to return an empty json once we reach timeout.